### PR TITLE
fix bug of sort processlist

### DIFF
--- a/Xprocess/XprocessDlg.cpp
+++ b/Xprocess/XprocessDlg.cpp
@@ -241,6 +241,7 @@ void CXprocessDlg::ListProcess(WCHAR * Text,int sort)
 		break;
 	case 2:
 		std::sort(v.begin(), v.end(), SortByPATH);
+		break;
 	default:
 		std::sort(v.begin(), v.end(), SortByName);
 	}


### PR DESCRIPTION
Obviously, the result of sort by "Name" is the same of sort by "Path". Because of the "case 2" of "sort switch" is missing "break" at the end of "case", and the "default case" will be executed after executing "case 2" if "sort == 2".